### PR TITLE
Show avaliable ports and arguments

### DIFF
--- a/Processing/HMC5883L_processing/HMC5883L_processing.pde
+++ b/Processing/HMC5883L_processing/HMC5883L_processing.pde
@@ -45,8 +45,11 @@ void setup ()
   // Init
   initCompass();
 
+  // List all the available serial ports:
+  printArray(args);
+  printArray(Serial.list());
   // Serial
-  myPort = new Serial(this, Serial.list()[0], 9600);
+  myPort = new Serial(this, Serial.list()[4], 9600);
   myPort.bufferUntil(10);
 }
 


### PR DESCRIPTION
first serial port avaliable is not always the correct port.

I run this branch with:

```
$ processing-java --sketch=/home/alberto/Downloads/Arduino-HMC5883L/Processing/HMC5883L_processing --run --force --no-java --platform=linux
```

Which returns this args:

```
[0] "--force"
[1] "--no-java"
[2] "--platform=linux"
```

And this serial ports:

```
[0] "/dev/ttyS0"
[1] "/dev/ttyS1"
[2] "/dev/ttyS2"
[3] "/dev/ttyS3"
[4] "/dev/ttyUSB0"
```

/dev/ttyUSB0 is the one that is correct in my case. I want to receive the port as an argument but with `setup()` receiving arguments from `processing-java` not sure how to filter that and process only arguments for this sketch.

Apart from that, all the sketch works smooth and correctly.
