### PR TITLE
Fix mG per digit resolution from 0.073 to 0.73

### DIFF
--- a/HMC5883L.cpp
+++ b/HMC5883L.cpp
@@ -79,7 +79,7 @@ void HMC5883L::setRange(hmc5883l_range_t range)
     switch(range)
     {
 	case HMC5883L_RANGE_0_88GA:
-	    mgPerDigit = 0.073f;
+	    mgPerDigit = 0.73f;
 	    break;
 
 	case HMC5883L_RANGE_1_3GA:


### PR DESCRIPTION
According to the datasheet this should be 0.73 instead of 0.073